### PR TITLE
Escape LIKE wildcards in keyword search patterns

### DIFF
--- a/ContentSearch/core/EvoContentSearch.php
+++ b/ContentSearch/core/EvoContentSearch.php
@@ -358,6 +358,7 @@ class EvoContentSearch
      */
     private function generateRelevanceScore($keyword) {
         $escaped = db()->escape($keyword);
+        $escapedLike = db()->escape($this->escapeLikeWildcard($keyword));
 
         return sprintf("
             (
@@ -410,16 +411,16 @@ class EvoContentSearch
 
             ) as relevance_score
         ",
-            $escaped,  // タイトル完全一致
-            $escaped,  // タイトル先頭一致
-            $escaped,  // タイトル部分一致
-            $escaped,  // ディスクリプション
-            $escaped,  // 本文冒頭
-            $escaped,  // 短いキーワードチェック用
-            $escaped,  // 短いキーワード: タイトル
-            $escaped,  // 短いキーワード: 本文冒頭
-            $escaped,  // キーワード密度計算用
-            $escaped   // キーワード密度計算用
+            $escaped,      // タイトル完全一致
+            $escapedLike,  // タイトル先頭一致
+            $escapedLike,  // タイトル部分一致
+            $escapedLike,  // ディスクリプション
+            $escapedLike,  // 本文冒頭
+            $escaped,      // 短いキーワードチェック用
+            $escapedLike,  // 短いキーワード: タイトル
+            $escapedLike,  // 短いキーワード: 本文冒頭
+            $escaped,      // キーワード密度計算用
+            $escaped       // キーワード密度計算用
         );
     }
 
@@ -570,6 +571,8 @@ class EvoContentSearch
     }
 
     private function likeWhere($keyword) {
+        $keyword = $this->escapeLikeWildcard($keyword);
+
         $_ = explode(' ', $keyword);
         if(count($_)==1) {
             return evo()->parseText(
@@ -585,6 +588,17 @@ class EvoContentSearch
             );
         }
         return implode(' AND ', $where);
+    }
+
+    private function escapeLikeWildcard($keyword) {
+        return strtr(
+            $keyword,
+            [
+                '\\' => '\\\\',
+                '%' => '\\%',
+                '_' => '\\_'
+            ]
+        );
     }
 
     private function summary($text, $keyword) {


### PR DESCRIPTION
## Summary
- escape user keywords for LIKE patterns to avoid unintended wildcard matches
- apply escaped LIKE values in relevance scoring and filtering logic
- add helper to normalize special characters used in LIKE queries

## Testing
- php -l core/EvoContentSearch.php


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692d91b801b8832da906b729714ba86b)