### PR TITLE
Fix SQL ESCAPE character handling in search scoring

### DIFF
--- a/ContentSearch/core/EvoContentSearch.php
+++ b/ContentSearch/core/EvoContentSearch.php
@@ -586,7 +586,7 @@ class EvoContentSearch
         $_ = explode(' ', $keyword);
         if(count($_)==1) {
             return sprintf(
-                "plain_text LIKE CONCAT('%%%s%%') ESCAPE '%s'",
+                "plain_text LIKE '%%%s%%' ESCAPE '%s'",
                 db()->escape($keyword),
                 $escapeChar
             );
@@ -594,7 +594,7 @@ class EvoContentSearch
         $where = [];
         foreach($_ as $v) {
             $where[] = sprintf(
-                "plain_text LIKE CONCAT('%%%s%%') ESCAPE '%s'",
+                "plain_text LIKE '%%%s%%' ESCAPE '%s'",
                 db()->escape($v),
                 $escapeChar
             );

--- a/ContentSearch/core/EvoContentSearch.php
+++ b/ContentSearch/core/EvoContentSearch.php
@@ -324,11 +324,16 @@ class EvoContentSearch
     private function likeQuery($keyword) {
         $keyword = trim($keyword);
         $escapedKeyword = db()->escape($keyword);
+        $occurrenceCountExpr = sprintf(
+            "(LENGTH(stext.plain_text) - LENGTH(REPLACE(stext.plain_text, '%s', ''))) / LENGTH('%s')",
+            $escapedKeyword,
+            $escapedKeyword
+        );
         $field = [
             sprintf(
-                "stext.*,content.*,(LENGTH(stext.plain_text) - LENGTH(REPLACE(stext.plain_text, '%s', ''))) / LENGTH('%s') AS cnt",
-                $escapedKeyword,
-                $escapedKeyword
+                "stext.*,content.*, %s AS cnt, %s AS base_score",
+                $occurrenceCountExpr,
+                $occurrenceCountExpr
             )
         ];
         if($this->orderby==='rel') {


### PR DESCRIPTION
## Summary
- switch LIKE escape handling to use a dedicated escape character and consistent escaping
- update relevance score calculation and LIKE filters to share the escape character

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692fdd723344832d9a5283e07fc7b453)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **改善**
  * 検索のエスケープ処理を統一・動的化しました。ワイルドカードや特殊文字の扱いが一貫し、タイトル／説明／本文を横断する一致精度が向上します。短い語句や特殊文字を含む複雑な検索でも、より正確で期待通りの結果が得られます。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->